### PR TITLE
Document Close and Release device session and mark device for reboot

### DIFF
--- a/open_api_specification.yaml
+++ b/open_api_specification.yaml
@@ -71,6 +71,14 @@ paths:
       description: Retrieves a list of device sessions, including pending, active and recently closed sessions.
       tags:
         - "Session Lifecycle"
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Filter out sessions returned based on status
+          schema:
+            $ref: "#/components/schemas/SessionStatus"
+
       responses:
         "200":
           description: OK
@@ -115,16 +123,12 @@ paths:
           description: The id of the device session
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                rebootDevice:
-                  type: boolean
-                  default: false
-                  description: Perform a device reboot after session release. Only applicable for private devices.
+        - name : rebootDevice
+          in: query
+          required: false
+          description: Perform a device reboot after session release. Only applicable for private devices.
+          schema:
+            $ref: "#/components/schemas/RebootDevice"
       responses:
         "200":
           $ref: "#/components/responses/CloseDeviceSession"
@@ -400,3 +404,6 @@ components:
         - "CLOSED"
         - "ERRORED"
       example: "CREATING"
+    RebootDevice:
+      type: boolean
+      default: false


### PR DESCRIPTION
## Description

1. We would like to offer api users with the ability to reboot the device when releasing a device from an rdc device api session
2. When retrieving the api session we need to allow filtering by `status`

## Types of Changes
- Documentation / non-code

## Deployment Notes

1. DELETE request accepts a query param with a rebootDevice flag.
2. GET request accepts a query param with a status filtering flag
