### PR TITLE
Mark os param as optional during api session creation

### DIFF
--- a/open_api_specification.yaml
+++ b/open_api_specification.yaml
@@ -56,7 +56,6 @@ paths:
                       type: string
                       enum: [android, ios]
                       example: ios
-                      required: false
       responses:
         "200":
           description: Ok


### PR DESCRIPTION

## Description
Mark os param as optional during api session creation

## Types of Changes

- Documentation / non-code

