### PR TITLE
Fix Open api doc: 'id' is wrongly documented as 'sessionId'

### DIFF
--- a/open_api_specification.yaml
+++ b/open_api_specification.yaml
@@ -722,7 +722,7 @@ components:
     Session:
       type: object
       properties:
-        sessionId:
+        id:
           $ref: "#/components/schemas/SessionId"
         state:
           $ref: "#/components/schemas/SessionState"
@@ -772,7 +772,7 @@ components:
     SessionCreation:
       type: object
       properties:
-        sessionId:
+        id:
           type: string
         state:
           $ref: "#/components/schemas/SessionState"


### PR DESCRIPTION
Fix Open api doc: 'id' is wrongly documented as 'sessionId'