### PR TITLE
Add documentation for startAppiumServer endpoint and ephemeral apps

### DIFF
--- a/open_api_specification.yaml
+++ b/open_api_specification.yaml
@@ -328,17 +328,17 @@ paths:
                   type: string
                   description: The appium version to use. Please check https://docs.saucelabs.com/mobile-apps/automated-testing/appium/appium-versions/#real-devices
                   example: "latest"
-        responses:
-          "200":
-            description: Command executed successfully
-            content:
-              application/json:
-                schema:
-                  type: object
-          "400":
-            $ref: "#/components/responses/BadRequest"
-          "404":
-            $ref: "#/components/responses/DeviceSessionNotFound"
+      responses:
+        "200":
+          description: Command executed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/DeviceSessionNotFound"
 
   /sessions/{sessionId}/device/proxy/http/{targetHost}/{targetPort}/{targetPath}:
     get:
@@ -810,7 +810,7 @@ components:
             appiumUrl:
               type: string
               example: "https://api.staging.saucelabs.net/rdc/v2/sessions/123e4567-e89b-12d3-a456-426614174000/appium/wd/hub"
-              description: Appium endpoint for this session
+              description: Endpoint to reach the appium-server for your session. Please note that you should start the server via /sessions/{sessionId}/device/startAppiumServer
             self:
               type: string
               example: "https://api.saucelabs.com/rdc/v2/sessions/123e4567-e89b-12d3-a456-426614174000"


### PR DESCRIPTION
# Add documentation for startAppiumServer endpoint and ephemeral apps

## Description
Adds documentation for the new `/startAppiumServer` server endpoint, `appiumUrl` field and ephemeral app support for app installations.