### PR TITLE
Document Endpoint to Modify Device Settings

### DIFF
--- a/open_api_specification.yaml
+++ b/open_api_specification.yaml
@@ -371,7 +371,7 @@ paths:
                   example: "PORTRAIT"
                 locale:
                   type: string
-                  description: "**Android only.** Sets the system-wide language and country. The format should be a standard locale identifier (e.g., `language_COUNTRY`). This setting is not supported on **iOS** because it requires a device reboot."
+                  description: "**Android only.** Sets the system-wide language and country. The value must be a valid IETF BCP 47 language tag (e.g., 'en-US', 'fr-CA'). This setting is not supported on **iOS** because it requires a device reboot."
                   example: "en_US"
                 animations:
                   type: boolean


### PR DESCRIPTION
## Description
This PR adds the new POST `/sessions/{sessionId}/device/applySettings` endpoint to the public OpenAPI specification. This endpoint allows users to change device settings like orientation, locale, and animations during a session.

## Types of Changes
- New feature (non-breaking change which adds functionality)


## Tasks

- [x] Add complete specification for the applySettings endpoint.

